### PR TITLE
This closes #20, closes #27

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,4 +4,4 @@ JSON
 Dates
 HttpCommon
 Requests
-Codecs
+Compat

--- a/src/GitHub.jl
+++ b/src/GitHub.jl
@@ -4,10 +4,16 @@ module GitHub
 import Base.show
 
 import JSON
-using Dates
+using Compat
 using HttpCommon
 using Requests
-using Codecs #only until julia 0.4 introduces base function for base64 encoding???
+import Requests: get, post, put, delete, options
+
+if VERSION < v"0.4-"
+    using Dates
+else
+    using Base.Dates
+end
 
 abstract GitHubType
 abstract Owner <: GitHubType

--- a/src/auth.jl
+++ b/src/auth.jl
@@ -38,7 +38,7 @@ end
 function authenticate(token::String)
     auth = OAuth2(token)
 
-    r = get(API_ENDPOINT; query = { "access_token" => auth.token })
+    r = get(API_ENDPOINT; query = @compat Dict("access_token" => auth.token))
     if r.status < 200 || r.status >= 300
         data = JSON.parse(r.data)
         throw(AuthError(r.status, get(data, "message", ""), get(data, "documentation_url", "")))

--- a/src/repos.jl
+++ b/src/repos.jl
@@ -135,5 +135,5 @@ function contributors(auth::Authorization, owner, repo; headers = Dict(),
                       options...)
 
     data = get_items_from_pages(pages)
-    [ { "author" => User(c), "contributions" => c["contributions"] } for c in data ]
+    [ @compat Dict("author" => User(c), "contributions" => c["contributions"]) for c in data ]
 end

--- a/src/starring.jl
+++ b/src/starring.jl
@@ -7,7 +7,7 @@ end
 
 function stargazers(auth::Authorization, owner, repo; per_page = 30, headers = Dict(), result_limit = -1, options...)
     authenticate_headers(headers, auth)
-    query = ["per_page" => per_page]
+    query = @compat Dict("per_page" => per_page)
     pages = get_pages(URI(API_ENDPOINT; path = "/repos/$owner/$repo/stargazers"), result_limit, per_page;
                       headers = headers,
                       query = query,


### PR DESCRIPTION
`Compat.jl` requires Julia 0.3. So, I'm breaking your code for users of older versions. But, supporting 0.4 over 0.2 feels like progress.

`Compat.jl` takes care of the `base64` issue.

I think importing from `Requests.jl` fixes your reminder. But, I'm not exactly sure what you were referring to.